### PR TITLE
Add message header; Add serde with (de)serialization of header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +206,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 name = "nperf"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "clap",
  "env_logger",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bincode = "1.3.3"
 clap = { version = "4.4.14", features = ["derive"] }
 env_logger = "0.10.1"
 libc = "0.2.152"

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,8 +1,36 @@
 use std::net::Ipv4Addr;
 use std::str::FromStr;
+use bincode::{deserialize, serialize};
+use serde::{Deserialize, Serialize};
 
 pub mod socket;
 pub mod socket_options;
+
+#[repr(u8)]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum MessageType {
+    INIT = 0,
+    MEASUREMENT = 1,
+    LAST = 2
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MessageHeader {
+    pub mtype: MessageType,
+    pub test_id: u16,
+    pub packet_id: u64
+}
+
+impl MessageHeader {
+    pub fn serialize(&self) -> Vec<u8> {
+        serialize(&self).unwrap()
+    }
+
+    pub fn deserialize(buffer: &[u8]) -> MessageHeader {
+        // TODO: Currently static serde buffer size
+        deserialize::<MessageHeader>(&buffer[0..14]).unwrap()
+    }
+}
 
 pub fn parse_ipv4(adress: String) -> Result<Ipv4Addr, &'static str> {
     match Ipv4Addr::from_str(adress.as_str()) {

--- a/src/node/client.rs
+++ b/src/node/client.rs
@@ -119,18 +119,12 @@ impl Client {
         }
     }
 
-    fn add_test_id(&mut self) {
-        for packet_buffer in self.packet_buffer.iter_mut() {
-            packet_buffer.add_test_id(self.test_id);
-        }
-        debug!("Added test ID {} to buffer!", self.test_id);
-    }
 
     fn add_packet_ids(&mut self) -> Result<u64, &'static str> {
         let mut total_amount_used_packet_ids: u64 = 0;
 
         for packet_buffer in self.packet_buffer.iter_mut() {
-            let amount_used_packet_ids = packet_buffer.add_packet_ids(self.next_packet_id)?;
+            let amount_used_packet_ids = packet_buffer.add_message_header(self.test_id, self.next_packet_id)?;
             self.next_packet_id += amount_used_packet_ids;
             total_amount_used_packet_ids += amount_used_packet_ids;
         }
@@ -152,7 +146,6 @@ impl Client {
 impl Node for Client {
     fn run(&mut self, io_model: IOModel) -> Result<Statistic, &'static str> {
         self.fill_packet_buffers_with_repeating_pattern(); 
-        self.add_test_id();
         self.socket.connect().expect("Error connecting to remote host"); 
 
         if let Ok(mss) = self.socket.get_mss() {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,6 +8,8 @@ use log::{debug, trace, warn};
 use serde::Serialize;
 use statistic::Statistic;
 
+use crate::net::MessageHeader;
+
 use self::packet_buffer::PacketBuffer;
 
 #[derive(PartialEq, Debug, Copy, Clone, Serialize)]
@@ -30,6 +32,7 @@ pub enum IOModel {
     Poll,
 }
 
+
 pub fn parse_mode(mode: String) -> Option<NPerfMode> {
     match mode.as_str() {
         "client" => Some(NPerfMode::Client),
@@ -39,7 +42,7 @@ pub fn parse_mode(mode: String) -> Option<NPerfMode> {
 }
 
 pub fn get_packet_test_id(packet: &[u8]) -> u16 {
-    u16::from_be_bytes(packet[0..2].try_into().unwrap())
+    MessageHeader::deserialize(packet).test_id
 }
 
 pub fn process_packet_buffer(buffer: &[u8], datagram_size: usize, next_packet_id: u64, statistic: &mut Statistic) -> u64 {
@@ -51,9 +54,7 @@ pub fn process_packet_buffer(buffer: &[u8], datagram_size: usize, next_packet_id
 }
 
 pub fn process_packet(buffer: &[u8], next_packet_id: u64, statistic: &mut Statistic) -> u64 {
-    // FIXME: buffer can contain more than one packet
-    // Slice the buffer into datagram_size slices, Iterate over the buffer and process each packet
-    let packet_id = u64::from_be_bytes(buffer[2..10].try_into().unwrap());
+    let packet_id = MessageHeader::deserialize(buffer).packet_id;
     debug!("Received packet number: {}", packet_id);
     process_packet_number(packet_id, next_packet_id, statistic)
 }


### PR DESCRIPTION
Through using Serde, to serialize the message header, the performance drops by 40%.